### PR TITLE
BUGFIX: Fix OptionsSchema check for "callable" options for PHP 8+

### DIFF
--- a/Classes/OptionsSchema.php
+++ b/Classes/OptionsSchema.php
@@ -101,7 +101,7 @@ final class OptionsSchema
             $expectedType = $optionSchema['type'] ?? 'string';
             $actualType = TypeHandling::getTypeForValue($options[$optionName]);
             if ($expectedType === 'callable') {
-                if (!\is_callable($options[$optionName])) {
+                if (!\is_callable($options[$optionName], true)) {
                     throw new \InvalidArgumentException(sprintf('Option "%s" must be a callable in the format: "Some\ClassName::someMethodName" but it is: "%s" and that is not callable', $optionName, \is_string($options[$optionName]) ? $options[$optionName] : $actualType), 1563962182);
                 }
             } elseif ($actualType !== $expectedType) {


### PR DESCRIPTION
Adjust the schema check for `callable` options to only check for the syntax
not whether the method is actually callable.

The behavior of the `is_callable()` function has been changed with PHP 8:
Previously `is_callable('<ClassName>::<methodName>')` returned `true` whether
the method was static or not.
With PHP 8 and newer that check returns `false`.

Fixes: #2