### PR TITLE
FEATURE: Dynamic presets

### DIFF
--- a/Classes/ImportServiceFactory.php
+++ b/Classes/ImportServiceFactory.php
@@ -51,6 +51,11 @@ final class ImportServiceFactory
         return new ImportService($this->createPreset($presetName)->withDataSource($dataSource));
     }
 
+    public function createWithDataSourceAndTarget(string $presetName, DataSourceInterface $dataSource, DataTargetInterface $dataTarget): ImportService
+    {
+        return new ImportService($this->createPreset($presetName)->withDataSourceAndTarget($dataSource, $dataTarget));
+    }
+    
     public function createPreset(string $presetName): Preset
     {
         $presetConfiguration = $this->getPresetConfiguration($presetName);

--- a/Classes/ImportServiceFactory.php
+++ b/Classes/ImportServiceFactory.php
@@ -32,6 +32,11 @@ final class ImportServiceFactory
         return new ImportService($this->createPreset($presetName));
     }
 
+    public function createFromPreset(Preset $preset): ImportService
+    {
+        return new ImportService($preset);
+    }
+
     public function createWithFixture(string $presetName): ImportService
     {
         $preset = $this->createPreset($presetName);
@@ -51,11 +56,6 @@ final class ImportServiceFactory
         return new ImportService($this->createPreset($presetName)->withDataSource($dataSource));
     }
 
-    public function createWithDataSourceAndTarget(string $presetName, DataSourceInterface $dataSource, DataTargetInterface $dataTarget): ImportService
-    {
-        return new ImportService($this->createPreset($presetName)->withDataSourceAndTarget($dataSource, $dataTarget));
-    }
-    
     public function createPreset(string $presetName): Preset
     {
         $presetConfiguration = $this->getPresetConfiguration($presetName);

--- a/Classes/Preset.php
+++ b/Classes/Preset.php
@@ -56,6 +56,14 @@ final class Preset
         if (!$dataSource instanceof DataSourceInterface) {
             throw new \RuntimeException(sprintf('The configured "source.className" is not an instance of %s', DataSourceInterface::class), 1557238800);
         }
+        return self::fromConfigurationWithDataSource($configuration, $dataSource);
+    }
+
+    /**
+     * Create a Preset from a given Configuration. Additionally passing extra defined datasource like e.g. ClosureDataSource
+     */
+    public static function fromConfigurationWithDataSource(array $configuration, DataSourceInterface $dataSource): self
+    {
         if (!isset($configuration['mapping'])) {
             throw new \RuntimeException(sprintf('Missing "mapping" configuration'), 1558080904);
         }
@@ -93,11 +101,6 @@ final class Preset
     public function withDataSource(DataSourceInterface $dataSource): self
     {
         return new static($dataSource, $this->dataTarget, $this->options);
-    }
-    
-    public function withDataSourceAndTarget(DataSourceInterface $dataSource, DataTargetInterface $dataTarget): self
-    {
-        return new static($dataSource, $dataTarget, $this->options);
     }
 
     public function isSkipAddedRecords(): bool

--- a/Classes/Preset.php
+++ b/Classes/Preset.php
@@ -94,6 +94,11 @@ final class Preset
     {
         return new static($dataSource, $this->dataTarget, $this->options);
     }
+    
+    public function withDataSourceAndTarget(DataSourceInterface $dataSource, DataTargetInterface $dataTarget): self
+    {
+        return new static($dataSource, $dataTarget, $this->options);
+    }
 
     public function isSkipAddedRecords(): bool
     {


### PR DESCRIPTION
Add a variant to fromConfiguration() and additionally created createFromPreset()

Background: The idea here is to enable dynamically overriding the Datasource and Nodepaths in ContentRepositoryTarget after loading the inital datasource config. Thus import the same Preset under different paths depending on the imported objects context and/or using a different datasource.