### PR TITLE
Task/readme note

### DIFF
--- a/Classes/Preset.php
+++ b/Classes/Preset.php
@@ -120,7 +120,7 @@ final class Preset
             [$className, $methodName] = explode('::', $this->options['dataProcessor'], 2);
             $records = \call_user_func([new $className(), $methodName], $records);
             if (!$records instanceof DataRecords) {
-                throw new \RuntimeException(sprintf('The "dataPostprocessor" must return an instance of %s but returned a %s', DataRecords::class, TypeHandling::getTypeForValue($records)), 1563978776);
+                throw new \RuntimeException(sprintf('The "dataProcessor" must return an instance of %s but returned a %s', DataRecords::class, TypeHandling::getTypeForValue($records)), 1563978776);
             }
         }
         return $records;

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Which should produce the output
 
 ```bash
 Validating Settings configuration on path Wwwision.ImportService
- 
+
 All Valid!
+```
+
+### Usage without Neos.ContentRepository package
+
+If the Neos.ContentRepository package is not installed Flow's proxy class builder throws an `UnknownObjectException`.
+Disable autowiring in `Objects.yaml`:
+
+```yaml
+Wwwision\ImportService\DataTarget\ContentRepositoryTarget:
+  autowiring: false
 ```

--- a/Resources/Private/Schema/Settings/Wwwision.ImportService.schema.yaml
+++ b/Resources/Private/Schema/Settings/Wwwision.ImportService.schema.yaml
@@ -11,11 +11,11 @@ properties:
         'options':
           type: dictionary
           properties:
-            'skipNewRecords':
+            'skipAddedRecords':
               type: boolean
             'skipRemovedRecords':
               type: boolean
-            'dataPostProcessor':
+            'dataProcessor':
               type: string
               pattern: '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\\]*::[a-zA-Z_\x7f-\xff]*$/u'
         'source':


### PR DESCRIPTION
Hi there

Neat extension, started to work on something similar before stumbling upon it  :-)
I've noticed that [Wwwision\ImportService\DataTarget\ContentRepositoryTarget](https://github.com/bwaidelich/Wwwision.ImportService/blob/master/Classes/DataTarget/ContentRepositoryTarget.php) has a dependency on the Neos.ContentRepository package which will make Flow's proxy class builder throw an `UnknownObjectException` if not installed. Added a note to the readme on how to disable autowiring for the class. Minor update in the schema too.

Cheers

Marc